### PR TITLE
Fix multisource clienttoken

### DIFF
--- a/builder/tencentcloud/cvm/step_run_instance.go
+++ b/builder/tencentcloud/cvm/step_run_instance.go
@@ -173,7 +173,7 @@ func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	s.instanceId = *resp.Response.InstanceIdSet[0]
-	Message(state, "Waiting for instance ready", "")
+	Message(state, fmt.Sprintf("Instance %s created, waiting for instance ready", s.instanceId), "")
 
 	err = WaitForInstance(ctx, client, s.instanceId, "RUNNING", 1800)
 	if err != nil {

--- a/builder/tencentcloud/cvm/step_run_instance.go
+++ b/builder/tencentcloud/cvm/step_run_instance.go
@@ -11,6 +11,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/uuid"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
 )
 
@@ -125,7 +126,11 @@ func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) mul
 			req.InternetAccessible.BandwidthPackageId = &s.BandwidthPackageId
 		}
 	}
-	req.InstanceName = &s.InstanceName
+
+	// Generate a unique ClientToken for each RunInstances request
+	clientToken := uuid.TimeOrderedUUID()
+	req.ClientToken = &clientToken
+
 	loginSettings := cvm.LoginSettings{}
 	if password != "" {
 		loginSettings.Password = &password
@@ -135,7 +140,7 @@ func (s *stepRunInstance) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	req.LoginSettings = &loginSettings
 	req.SecurityGroupIds = []*string{&security_group_id}
-	req.ClientToken = &s.InstanceName
+	req.InstanceName = &s.InstanceName
 	req.HostName = &s.HostName
 	req.UserData = &userData
 	req.CamRoleName = &s.CamRoleName


### PR DESCRIPTION
@Jalle19
The purpose of ClientToken is to ensure request idempotency in case the request needs to be retried. This means the value must be unique for all unique RunInstances API calls.

When building a template that references the same source multiple times (or multiple different sources), many calls to RunInstances are made. However, the same auto-generated instance name was used as ClientToken.

This changes ClientToken to be unique regardless of whether the user has supplied a unique instance_name for each source/build.

Fixes https://github.com/hashicorp/packer-plugin-tencentcloud/issues/6

Added additional logging for the instance IDs created to ease debugging.

